### PR TITLE
Escape field name in "total" query

### DIFF
--- a/src/IdGenerator.php
+++ b/src/IdGenerator.php
@@ -129,7 +129,7 @@ class IdGenerator
         $whereString = rtrim($whereString, 'AND ');
 
 
-        $totalQuery = sprintf("SELECT count(%s) total FROM %s %s", $field, $configArr['table'], $whereString);
+        $totalQuery = sprintf("SELECT count(`%s`) total FROM %s %s", $field, $configArr['table'], $whereString);
         $total = DB::select(trim($totalQuery));
 
         if ($total[0]->total) {


### PR DESCRIPTION
Using field name like "index" causes error, because index is reserved word and need to by escaped.

`Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'index) total FROM issues' at line 1 (Connection: mysql, SQL: SELECT count(index) total FROM issues)`